### PR TITLE
Exposed decorations to the renderElement callback

### DIFF
--- a/src/components/editable.tsx
+++ b/src/components/editable.tsx
@@ -84,6 +84,7 @@ const Children = (props: Parameters<typeof useChildren>[0]) => (
 export interface RenderElementProps {
   children: any
   element: Element
+  decorations: Range[],
   attributes: {
     'data-slate-node': 'element'
     'data-slate-inline'?: true

--- a/src/components/element.tsx
+++ b/src/components/element.tsx
@@ -131,7 +131,7 @@ const Element = (props: {
     NODE_TO_PARENT.set(text, element)
   }
 
-  return renderElement({ attributes, children, element })
+  return renderElement({ attributes, children, element, decorations })
 }
 
 const MemoizedElement = React.memo(Element, (prev, next) => {


### PR DESCRIPTION
This exposes the `decorations` to elements rendered by `renderElement` so that they can properly render styles that may be needed due to being children to a style-effecting parent in the markdown tree.
This is essentially implementing what a maintainer mentioned: https://github.com/ianstormtaylor/slate/issues/4392#issuecomment-909451939

We can, and should in the future, upstream this change.

This is needed for the new `subtext` markdown feature and will also be needed to power the slate implementation of the `heading` markdown feature in the future.